### PR TITLE
Replace fake API requests with B/E starter APIs

### DIFF
--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -1,10 +1,9 @@
+import axios from "@/lib/axios.config";
 import { fakeApi } from "@/lib/utils/misc.utils";
+import { ForgotPassword } from "../types/auth.type";
 
-async function login({ email }: { email: string; password: string }) {
-  return fakeApi(() => ({
-    accessToken: email.toLowerCase(),
-    refreshToken: "refreshToken",
-  })) as Promise<{ accessToken: string; refreshToken: string }>;
+async function login({ email, password }: { email: string; password: string }) {
+  return axios.post("auth/login", { email: email, password: password });
 }
 
 async function logout() {
@@ -12,16 +11,55 @@ async function logout() {
 }
 
 async function refreshToken() {
-  return fakeApi(() => ({
-    accessToken: "accessToken",
-    refreshToken: "refreshToken",
-  })) as Promise<{ accessToken: string; refreshToken: string }>;
+  const token = localStorage.getItem("refreshToken");
+  const res = await axios.post(
+    "auth/refresh",
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+  return {
+    accessToken: res.data.accessToken,
+    refreshToken: res.data.refreshToken,
+  };
 }
+
+const changePassword = async (password: string) => {
+  const res = await axios.post<string>("auth/changePassword", password, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  return res.data;
+};
+const forgotPassword = async (email: string) => {
+  const res = await axios.post("/auth/forgotPassword", email, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  return res.data;
+};
+
+const resetPassword = async (data: ForgotPassword) => {
+  const res = await axios.post("/auth/resetPassword", data, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  return res.data;
+};
 
 const authService = {
   login,
   logout,
   refreshToken,
+  changePassword,
+  forgotPassword,
+  resetPassword,
 };
 
 export default authService;

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -1,9 +1,14 @@
 import axios from "@/lib/axios.config";
 import { fakeApi } from "@/lib/utils/misc.utils";
-import { ForgotPassword } from "../types/auth.type";
+import {
+  ForgotPassword,
+  Login,
+  Password,
+  ResetPassword,
+} from "../types/auth.type";
 
-async function login({ email, password }: { email: string; password: string }) {
-  return axios.post("auth/login", { email: email, password: password });
+async function login(data: Login) {
+  return await axios.post("auth/login", data);
 }
 
 async function logout() {
@@ -27,30 +32,15 @@ async function refreshToken() {
   };
 }
 
-const changePassword = async (password: string) => {
-  const res = await axios.post<string>("auth/changePassword", password, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  return res.data;
+const changePassword = async (data: Password) => {
+  return await axios.post("auth/changePassword", data);
 };
-const forgotPassword = async (email: string) => {
-  const res = await axios.post("/auth/forgotPassword", email, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  return res.data;
+const forgotPassword = async (data: ForgotPassword) => {
+  return await axios.post("/auth/forgotPassword", data);
 };
 
-const resetPassword = async (data: ForgotPassword) => {
-  const res = await axios.post("/auth/resetPassword", data, {
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  return res.data;
+const resetPassword = async (data: ResetPassword) => {
+  return await axios.post("/auth/resetPassword", data);
 };
 
 const authService = {

--- a/src/modules/auth/slices/auth.slice.ts
+++ b/src/modules/auth/slices/auth.slice.ts
@@ -2,6 +2,7 @@ import { RouterConfig } from "@/lib/router/router-config";
 import { ThunkStatus } from "@/lib/types/misc";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import authService from "../services/auth.service";
+import { ForgotPassword } from "../types/auth.type";
 
 export const name = "auth";
 
@@ -12,28 +13,51 @@ const initialState: {
   status: "processing" | "authenticated" | "unauthenticated";
   loginStatus: ThunkStatus;
   logoutStatus: ThunkStatus;
+  changePasswordStatus: ThunkStatus;
+  resetPasswordStatus: ThunkStatus;
+  forgotPasswordStatus: ThunkStatus;
 } = {
   computedRoutes: undefined,
   sidebarCollapsed: false,
   status: "processing",
   loginStatus: ThunkStatus.IDLE,
   logoutStatus: ThunkStatus.IDLE,
+  changePasswordStatus: ThunkStatus.IDLE,
+  resetPasswordStatus: ThunkStatus.IDLE,
+  forgotPasswordStatus: ThunkStatus.IDLE,
 };
 
 const login = createAsyncThunk(
   `${name}/login`,
   async (data: Parameters<typeof authService.login>[0]) => {
     const res = await authService.login(data);
-    localStorage.setItem("accessToken", res.accessToken);
-    localStorage.setItem("refreshToken", res.refreshToken);
+    localStorage.setItem("accessToken", res.data.accessToken);
+    localStorage.setItem("refreshToken", res.data.refreshToken);
     return res;
   }
 );
 const logout = createAsyncThunk(`${name}/logout`, async () => {
-  await authService.logout();
   localStorage.removeItem("accessToken");
   localStorage.removeItem("refreshToken");
 });
+const changePassword = createAsyncThunk(
+  `${name}/changePassword`,
+  async (password: string) => {
+    return await authService.changePassword(password);
+  }
+);
+const forgotPassword = createAsyncThunk(
+  `${name}/forgotPassword`,
+  async (email: string) => {
+    return await authService.forgotPassword(email);
+  }
+);
+const resetPassword = createAsyncThunk(
+  `${name}/resetPassword`,
+  async (data: ForgotPassword) => {
+    return await authService.resetPassword(data);
+  }
+);
 
 //slice
 export const authSlice = createSlice({
@@ -61,4 +85,11 @@ export const authSlice = createSlice({
 });
 
 //action creators
-export const authActions = { ...authSlice.actions, login, logout };
+export const authActions = {
+  ...authSlice.actions,
+  login,
+  logout,
+  changePassword,
+  forgotPassword,
+  resetPassword,
+};

--- a/src/modules/auth/slices/auth.slice.ts
+++ b/src/modules/auth/slices/auth.slice.ts
@@ -2,7 +2,6 @@ import { RouterConfig } from "@/lib/router/router-config";
 import { ThunkStatus } from "@/lib/types/misc";
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import authService from "../services/auth.service";
-import { ForgotPassword } from "../types/auth.type";
 
 export const name = "auth";
 
@@ -42,21 +41,15 @@ const logout = createAsyncThunk(`${name}/logout`, async () => {
 });
 const changePassword = createAsyncThunk(
   `${name}/changePassword`,
-  async (password: string) => {
-    return await authService.changePassword(password);
-  }
+  authService.changePassword
 );
 const forgotPassword = createAsyncThunk(
   `${name}/forgotPassword`,
-  async (email: string) => {
-    return await authService.forgotPassword(email);
-  }
+  authService.forgotPassword
 );
 const resetPassword = createAsyncThunk(
   `${name}/resetPassword`,
-  async (data: ForgotPassword) => {
-    return await authService.resetPassword(data);
-  }
+  authService.resetPassword
 );
 
 //slice

--- a/src/modules/auth/types/auth.type.ts
+++ b/src/modules/auth/types/auth.type.ts
@@ -1,5 +1,15 @@
-export type ForgotPassword = {
+export type ResetPassword = {
   email: string;
   otp: string;
+  password: string;
+};
+export type Login = {
+  email: string;
+  password: string;
+};
+export type ForgotPassword = {
+  email: string;
+};
+export type Password = {
   password: string;
 };

--- a/src/modules/auth/types/auth.type.ts
+++ b/src/modules/auth/types/auth.type.ts
@@ -1,0 +1,5 @@
+export type ForgotPassword = {
+  email: string;
+  otp: string;
+  password: string;
+};


### PR DESCRIPTION
1. Replace all fake APIs with real ones, except for the logout API, as it is not available in Swagger.
2. Keep the profile API unchanged, as it was implemented in the feature-5/push-notification branch for push notification work